### PR TITLE
Only match exact main and subdomains

### DIFF
--- a/src/ExtractorFactory.php
+++ b/src/ExtractorFactory.php
@@ -46,7 +46,14 @@ class ExtractorFactory
         $class = $this->default;
 
         foreach ($this->adapters as $adapterHost => $adapter) {
-            if (substr($host, -strlen($adapterHost)) === $adapterHost) {
+            // Check if $host is the same domain as $adapterHost.
+            if ($host === $adapterHost) {
+                $class = $adapter;
+                break;
+            }
+
+            // Check if $host is a subdomain of $adapterHost.
+            if (preg_match('/^([a-z0-9-]+)\.' . preg_quote($adapterHost, '/') . '$/i', $host, $matches)) {
                 $class = $adapter;
                 break;
             }

--- a/src/ExtractorFactory.php
+++ b/src/ExtractorFactory.php
@@ -53,7 +53,7 @@ class ExtractorFactory
             }
 
             // Check if $host is a subdomain of $adapterHost.
-            if (preg_match('/^([a-z0-9-]+)\.' . preg_quote($adapterHost, '/') . '$/i', $host, $matches)) {
+            if (substr($host, -strlen($adapterHost) + 1) === ".{$adapterHost}") {
                 $class = $adapter;
                 break;
             }


### PR DESCRIPTION
The current host matching logic in ExtractorFactory checks if the host of the inputted url ends with the host of one of the adapters. That check is too broad though, it should only check exact matches and subdomain matches. Example: shop.weeztix.com urls are considered Twitter urls, because the host ends with x.com.